### PR TITLE
Remove default text alignment from stack()

### DIFF
--- a/grate/grid.styl
+++ b/grate/grid.styl
@@ -102,7 +102,7 @@ center(max_width = 1410px, pad = 0)
   padding-right: pad
 
 // Stacking/Unstacking Elements
-stack(pad = 0, align = center)
+stack(pad = 0, align = false)
   side = -get_layout_direction()
   display: block
   clear: both
@@ -120,12 +120,14 @@ stack(pad = 0, align = center)
   if pad != 0
     padding-left: pad
     padding-right: pad
-  if (align == center) or (align == c)
-    text-align: center
-  if (align == left) or (align == l)
-    text-align: left
-  if (align == right) or (align == r)
-    text-align: right
+
+  if (align != false)
+    if (align == center) or (align == c)
+      text-align: center
+    if (align == left) or (align == l)
+      text-align: left
+    if (align == right) or (align == r)
+      text-align: right
         
 unstack()
   side = -get_layout_direction()


### PR DESCRIPTION
It has caused a bunch of headaches in recent projects.
/cc @kylemac @joshrowley
